### PR TITLE
Fixed an error with '_locationPeriod' as a data criteria key

### DIFF
--- a/lib/cqm/converter/hds_record.rb
+++ b/lib/cqm/converter/hds_record.rb
@@ -43,7 +43,14 @@ module CQM::Converter
       cql_qdm_patient.keys.each do |dc_type|
         cql_qdm_patient[dc_type].each do |dc|
           # Convert snake_case to camelCase
-          dc_fixed_keys = dc.deep_transform_keys { |key| key.to_s.camelize(:lower) }
+          dc_fixed_keys = dc.deep_transform_keys do |key|
+            key = key.to_s
+            if key == '_locationPeriod'
+              key[1..key.length].camelize(:lower)
+            else
+              key.camelize(:lower)
+            end
+          end
 
           # Our Code model uses 'codeSystem' to describe the code system (since system is
           # a reserved keyword). The cql.Code calls this 'system', so make sure the proper

--- a/lib/cqm/converter/qdm_patient.rb
+++ b/lib/cqm/converter/qdm_patient.rb
@@ -252,9 +252,9 @@ module CQM::Converter
       hds_attrs['facility'][:values]&.each do |value|
         value['code'] = value.delete('Code')
         value[:display] = value['code'].delete(:title) if value['code']
-        value[:locationPeriodHigh] = Time.at(value['Locationperiod'].last).utc.strftime('%m/%d/%Y %l:%M %p').split.join(' ')
-        value[:locationPeriodLow] = Time.at(value['Locationperiod'].first).utc.strftime('%m/%d/%Y %l:%M %p').split.join(' ')
-        value.delete('Locationperiod')
+        value[:locationPeriodHigh] = Time.at(value['locationPeriod'].last).utc.strftime('%m/%d/%Y %l:%M %p').split.join(' ')
+        value[:locationPeriodLow] = Time.at(value['locationPeriod'].first).utc.strftime('%m/%d/%Y %l:%M %p').split.join(' ')
+        value.delete('locationPeriod')
       end
     end
 


### PR DESCRIPTION
`'_locationPeriod'` didn't serialize nicely into `camelCase` thanks to the leading underscore, so special-casing transform.

Pull requests into cqm-converter require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If applicable, the library version number in `cqm-converter.gemspec` has been updated

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
