### PR TITLE
No coded uncertainty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'cql_qdm_patientapi', github: 'projecttacoma/cql_qdm_patientapi', branch: 'bonnie-v3.1.1'
+gem 'cql_qdm_patientapi', github: 'projecttacoma/cql_qdm_patientapi', branch: 'bonnie-patch'
 
-# gem 'cqm-models', github: 'projecttacoma/cqm-models', branch: 'master'
+gem 'cqm-models', github: 'projecttacoma/cqm-models', branch: 'bonnie-patch'
 
 gemspec

--- a/cqm-converter.gemspec
+++ b/cqm-converter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'
   spec.add_runtime_dependency 'coffee-script'
-  spec.add_runtime_dependency 'cqm-models', '>= 1.0.2'
+  # spec.add_runtime_dependency 'cqm-models', '>= 1.0.2'
   spec.add_runtime_dependency 'execjs'
   spec.add_runtime_dependency 'health-data-standards', '>= 4.3.2'
   spec.add_runtime_dependency 'momentjs-rails'

--- a/cqm-converter.gemspec
+++ b/cqm-converter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'
   spec.add_runtime_dependency 'coffee-script'
-  # spec.add_runtime_dependency 'cqm-models', '>= 1.0.2'
+  spec.add_runtime_dependency 'cqm-models', '>= 1.0.2'
   spec.add_runtime_dependency 'execjs'
   spec.add_runtime_dependency 'health-data-standards', '>= 4.3.2'
   spec.add_runtime_dependency 'momentjs-rails'


### PR DESCRIPTION
Add runtime dependency back
Pull requests into cqm-converter require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1938
- [x] Internal ticket links to this PR
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
